### PR TITLE
Add meta tag description support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ The following templates are built-in:
 
 Templates have the following Tera blocks:
 - `title` - to override the default `<title>` (`config.title`);
+- `description` - to override the `<meta name="description">`'s content (`config.description`);
 - `extra_head` - to override styles and anything else in `<head>`;
 - `header` - to change the header (best to put this in a `<header>`);
 - `content` - to change the content (best to put this in a `<main>`).
+
+You can set a section or page description using `description` in your front matter.
+By default, the `description` in `config.toml` is used.
 
 You can define links to include in the header on the homepage in `config.toml`:
 ```toml

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ compile_sass = true
 build_search_index = false
 
 title = "Hook"
+description = "Hook is a theme for Zola"
 
 [markdown]
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Blog"
+description = "Example blog page for Zola"
 sort_by = "date"
 +++

--- a/content/blog/markdown.md
+++ b/content/blog/markdown.md
@@ -1,5 +1,6 @@
 +++
 title = "Markdown example"
+description = "This page demonstrates how Markdown looks in the Hook theme for Zola"
 date = 2021-07-30
 +++
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% block description %}{{ section.description | default(value=config.description) }}{% endblock description %}">
     <title>{% block title %}{{ config.title }}{% endblock title %}</title>
     {% block extra_head %}
     <link rel="stylesheet" href="{{ get_url(path='style.css', cachebust=true) }}">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,6 +1,7 @@
 {% extends "index.html" %}
 
 {% block title %}{{ config.title }} | {{ page.title }}{% endblock title %}
+{% block description %}{{ page.description | default(value=config.description) }}{% endblock description %}
 
 {% block header %}
 <header class="space">


### PR DESCRIPTION
This commit adds a 'description' block which uses either the description
from the section/page front matter, or the description defined in
the configuration.