### PR TITLE
Light/Dark mode switch refactor: toggle on `<html>`, use CSS vars

### DIFF
--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -2,7 +2,7 @@
 
 :root.light-mode {
     --foreground: #222222;
-    --background: #777777;
+    --background: #eeeeee;
     --secondary: gray;
     --tertiary: #dddddd;
     --accent: #3d3cba;

--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -1,51 +1,26 @@
 // MARK: Variables
 
-@media (prefers-color-scheme: light) {
-    :root.light {
-        --foreground: #222222;
-        --background: orange;
-        --secondary: gray;
-        --tertiary: #dddddd;
-        --accent: #3d3cba;
-    }
+:root.light-mode {
+    --foreground: #222222;
+    --background: #777777;
+    --secondary: gray;
+    --tertiary: #dddddd;
+    --accent: #3d3cba;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root.dark {
-        --foreground: #eeeeee;
-        --background: orange;
-        --secondary: #999999;
-        --tertiary: #444444;
-        --accent: #959bf0;
-    }
+:root.dark-mode {
+    --foreground: #eeeeee;
+    --background: #161616;
+    --secondary: #999999;
+    --tertiary: #444444;
+    --accent: #959bf0;
 }
 
 
 // MARK: Light/dark config
 
-.dark-mode-buttons {
-    position: absolute;
-    top: 1em;
-    right: 1em;
-}
-
-.dark-mode-button {
-    border: none;
-    background-color: transparent;
-
-    &:hover {
-        cursor: pointer;
-    }
-}
-
-
-// MARK: Styles
-
-body {
-    color: var(--foreground);
-    background-color: var(--background);
-
-    &:not(.dark-mode) {         
+html {
+    &.light-mode {         
         #dark-mode-on {
             display: inline;
         }
@@ -62,6 +37,31 @@ body {
             display: inline;
         }
     }
+}
+
+.dark-mode-buttons {
+    position: absolute;
+
+    top: 1em;
+    right: 1em;
+}
+
+.dark-mode-button {
+    border: none;
+    background-color: transparent;
+
+    &:hover {
+        cursor: pointer;
+    }
+}
+
+
+
+// MARK: Styles
+
+body {
+    color: var(--foreground);
+    background-color: var(--background);
 }
 
 .secondary {

--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -1,41 +1,46 @@
-// MARK: Variables
-
-:root.light-mode {
+@mixin light-theme {
     --foreground: #222222;
     --background: #eeeeee;
-    --secondary: gray;
+    --secondary: #808080;
     --tertiary: #dddddd;
     --accent: #3d3cba;
+    --accent-highlight: #171746;
+    --table-border: #d0d0d0;
+    --table-row: #f7f7f7;
 }
 
-:root.dark-mode {
+@mixin dark-theme {
     --foreground: #eeeeee;
     --background: #161616;
     --secondary: #999999;
     --tertiary: #444444;
     --accent: #959bf0;
+    --accent-highlight: #c2c5f6;
+    --table-border: var(--tertiary);
+    --table-row: #1e1e1e;
 }
 
+:root.light-mode {
+    @include light-theme;
 
-// MARK: Light/dark config
-
-html {
-    &.light-mode {         
-        #dark-mode-on {
-            display: inline;
-        }
-        #dark-mode-off {
-            display: none;
-        }
+    #dark-mode-on {
+        display: inline;
     }
 
-    &.dark-mode {
-        #dark-mode-on {
-            display: none;
-        }
-        #dark-mode-off {
-            display: inline;
-        }
+    #dark-mode-off {
+        display: none;
+    }
+}
+
+:root.dark-mode {
+    @include dark-theme;
+
+    #dark-mode-on {
+        display: none;
+    }
+
+    #dark-mode-off {
+        display: inline;
     }
 }
 
@@ -55,9 +60,17 @@ html {
     }
 }
 
+@media (prefers-color-scheme: light) {
+    :root {
+        @include light-theme;
+    }
+}
 
-
-// MARK: Styles
+@media (prefers-color-scheme: dark) {
+    :root {
+        @include dark-theme;
+    }
+}
 
 body {
     color: var(--foreground);
@@ -73,7 +86,7 @@ a, a:link, a:visited {
 }
 
 a:hover {
-    color: color-mix(in hsl, var(--accent) 30%, black);
+    color: var(--accent-highlight);
 }
 
 blockquote {
@@ -94,10 +107,10 @@ pre code {
 
 table {
     th, td {
-        border-color: color-mix(in hsl, var(--tertiary) 5%, black);
+        border-color: var(--table-border);
     }
 
     thead, tr:nth-child(even) {
-        background-color: color-mix(in hsl, var(--tertiary) 10%, white);
+        background-color: var(--table-row);
     }
 }

--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -1,116 +1,30 @@
-$foreground: #222222;
-$background: #eeeeee;
-$secondary: gray;
-$tertiary: #dddddd;
-$accent: #3d3cba;
-
-$foreground-dark: #eeeeee;
-$background-dark: #161616;
-$secondary-dark: #999999;
-$tertiary-dark: #444444;
-$accent-dark: #959bf0;
-
-@mixin light-theme {
-    color: $foreground;
-    background-color: $background;
-
-    .secondary {
-        color: $secondary;
-    }
-
-    a, a:link, a:visited {
-        color: $accent;
-    }
-
-    a:hover {
-        color: darken($accent, 30%);
-    }
-
-    blockquote {
-        border-left: 2px solid $secondary;
-    }
-
-    code {
-        background-color: $tertiary;
-    }
-
-    pre code {
-        background-color: transparent;
-    }
-
-    .footnote-definition sup {
-        color: $secondary;
-    }
-
-    table {
-        th, td {
-            border-color: darken($tertiary, 5%);
-        }
-
-        thead, tr:nth-child(even) {
-            background-color: lighten($tertiary, 10%);
-        }
-    }
-}
-
-@mixin dark-theme {
-    color: $foreground-dark;
-    background-color: $background-dark;
-
-    .secondary {
-        color: $secondary-dark;
-    }
-
-    a, a:link, a:visited {
-        color: $accent-dark;
-    }
-
-    a:hover {
-        color: lighten($accent-dark, 10%);
-    }
-
-    blockquote {
-        border-left: 2px solid $secondary-dark;
-    }
-
-    code {
-        background-color: $tertiary-dark;
-    }
-
-    pre code {
-        background-color: transparent;
-    }
-
-    .footnote-definition sup {
-        color: $secondary-dark;
-    }
-
-    table {
-        th, td {
-            border-color: $tertiary-dark;
-        }
-
-        thead, tr:nth-child(even) {
-            background-color: darken($tertiary-dark, 15%);
-        }
-    }
-}
+// MARK: Variables
 
 @media (prefers-color-scheme: light) {
-    body {
-        @include light-theme;
+    :root.light {
+        --foreground: #222222;
+        --background: orange;
+        --secondary: gray;
+        --tertiary: #dddddd;
+        --accent: #3d3cba;
     }
 }
 
 @media (prefers-color-scheme: dark) {
-    body {
-        @include dark-theme;
+    :root.dark {
+        --foreground: #eeeeee;
+        --background: orange;
+        --secondary: #999999;
+        --tertiary: #444444;
+        --accent: #959bf0;
     }
 }
 
+
+// MARK: Light/dark config
+
 .dark-mode-buttons {
     position: absolute;
-
     top: 1em;
     right: 1em;
 }
@@ -124,26 +38,66 @@ $accent-dark: #959bf0;
     }
 }
 
-body:not(.dark-mode) {
-    @include light-theme;
 
-    #dark-mode-on {
-        display: inline;
+// MARK: Styles
+
+body {
+    color: var(--foreground);
+    background-color: var(--background);
+
+    &:not(.dark-mode) {         
+        #dark-mode-on {
+            display: inline;
+        }
+        #dark-mode-off {
+            display: none;
+        }
     }
 
-    #dark-mode-off {
-        display: none;
+    &.dark-mode {
+        #dark-mode-on {
+            display: none;
+        }
+        #dark-mode-off {
+            display: inline;
+        }
     }
 }
 
-body.dark-mode {
-    @include dark-theme;
+.secondary {
+    color: var(--secondary);
+}
 
-    #dark-mode-on {
-        display: none;
+a, a:link, a:visited {
+    color: var(--accent);
+}
+
+a:hover {
+    color: color-mix(in hsl, var(--accent) 30%, black);
+}
+
+blockquote {
+    border-left: 2px solid var(--secondary);
+}
+
+code {
+    background-color: var(--tertiary);
+}
+
+pre code {
+    background-color: transparent;
+}
+
+.footnote-definition sup {
+    color: var(--secondary);
+}
+
+table {
+    th, td {
+        border-color: color-mix(in hsl, var(--tertiary) 5%, black);
     }
 
-    #dark-mode-off {
-        display: inline;
+    thead, tr:nth-child(even) {
+        background-color: color-mix(in hsl, var(--tertiary) 10%, white);
     }
 }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -75,21 +75,24 @@ table {
     border-spacing: 0;
 
     th, td {
-        border: 1px solid;
-        border-left: none;
+        border-width: 1px;
+        border-style: solid;
+        border-left-style: none;
         padding: 0.2em;
 
         &:first-child {
-            border-left: 1px solid;
+            border-left-width: 1px;
+            border-left-style: solid;
         }
     }
 
     th {
-        border-top: 1px solid;
+        border-top-width: 1px;
+        border-top-style: solid;
     }
 
     td {
-        border-top: none;
+        border-top-style: none;
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
     </div>
     <script>
         const cls = document.querySelector("html").classList;
-        const getSessionTheme = sessionStorage.getItem("theme");
+        const sessionTheme = sessionStorage.getItem("theme");
 
         function setDark() {
             cls.add("dark-mode");
@@ -71,20 +71,19 @@
             sessionStorage.setItem("theme", "light");
         }
 
-        if (getSessionTheme === "dark") {
-            setDark()
-        } else if (getSessionTheme === "light") {
-            setLight()
+        if (sessionTheme === "dark") {
+            setDark();
+        } else if (sessionTheme === "light") {
+            setLight();
         } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-            setDark()
+            setDark();
         }
 
         document.getElementById("dark-mode-on").addEventListener("click", function(e) {
-            setDark()
-            
+            setDark();
         });
         document.getElementById("dark-mode-off").addEventListener("click", function(e) {
-            setLight()
+            setLight();
         });
     </script>
     <noscript>

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,23 +57,34 @@
         <button class="dark-mode-button" id="dark-mode-off"><img src="{{ get_url(path='light_mode.svg') }}" width="24" height="24" alt="Light mode" aria-label="light mode toggle" title="Light mode"></button>
     </div>
     <script>
-        const cls = document.body.classList;
+        const cls = document.querySelector("html").classList;
         const getSessionTheme = sessionStorage.getItem("theme");
+
+        function setDark() {
+            cls.add("dark-mode");
+            cls.remove("light-mode");
+            sessionStorage.setItem("theme", "dark");
+        }
+        function setLight() {
+            cls.add("light-mode");
+            cls.remove("dark-mode");
+            sessionStorage.setItem("theme", "light");
+        }
+
         if (getSessionTheme === "dark") {
-            cls.toggle("dark-mode", true);
+            setDark()
         } else if (getSessionTheme === "light") {
-            cls.toggle("dark-mode", false);
+            setLight()
         } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-            cls.toggle("dark-mode", true);
+            setDark()
         }
 
         document.getElementById("dark-mode-on").addEventListener("click", function(e) {
-            cls.toggle("dark-mode", true);
-            sessionStorage.setItem("theme", "dark");
+            setDark()
+            
         });
         document.getElementById("dark-mode-off").addEventListener("click", function(e) {
-            cls.toggle("dark-mode", false);
-            sessionStorage.setItem("theme", "light");
+            setLight()
         });
     </script>
     <noscript>


### PR DESCRIPTION
## Background

Hello!

I tried using the theme, but the way dark/light mode was implemented made it hard to customize variables:
- Everything was nested in `body.dark`, requiring all styles to be duplicated across that and `body`
- SASS variables were separate for light/dark and reused

```scss
// Before
body.dark-mode {
    a, a:link, a:visited {
	color: orange;
    }
}

// After
a, a:link, a:visited {
    color: orange;
}
```

Variables can now be overridden too:
```scss
:root.dark-mode {
    --accent-color: orange;
}
```

## Contents
- Replaced SASS vars with CSS `var(--...)` to allow overriding
  - One set of variables, set on `:root.dark-mode` or `:root.light-mode`
  - (prevents all style code from being duplicated!)
- No longer nesting all styles in `body`
- Removed `@media (prefers-dark...)`, since JS logic already handles this
