### PR TITLE
Tweaks

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -9,7 +9,7 @@ body {
     font-family: Arial, Helvetica, sans-serif;
     font-size: 14pt;
 
-    line-height: 1.3em;
+    line-height: 1.5em;
 
     padding: 5em 25%;
 }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -56,6 +56,13 @@ pre {
 
     code {
         padding: 0;
+        min-width: 100%;
+        display: inline-block;
+    }
+
+    mark {
+        display: block;
+        width: 100%;
     }
 }
 

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -28,10 +28,6 @@ body {
     margin-bottom: 2em;
 }
 
-.doublespace {
-    margin-bottom: 4em;
-}
-
 .small {
     font-size: 75%;
 }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -47,7 +47,7 @@ blockquote {
 
 code {
     padding: 0.1em 0.2em;
-    font-size: 12pt;
+    font-size: 75%;
 }
 
 pre {

--- a/templates/page.html
+++ b/templates/page.html
@@ -24,6 +24,7 @@
 
         {% for taxonomy_name in sorted_taxonomies %}
         {% set terms = page.taxonomies[taxonomy_name] %}
+        {% if not terms %}{% continue %}{% endif %}
         - {{ taxonomy_name | capitalize }}:
         {% for term_name in terms %}
         {% set term = get_taxonomy_term(kind=taxonomy_name, term=term_name) %}


### PR DESCRIPTION
- Increase line-height from 1.3em to 1.5em
- Remove unused `doublespace` class
- Set code font size to 75%
- Fix code highlight (`<mark>`) display
  - The highlight now takes the full width even when overflowing
- Don't list empty taxonomies on pages