### PR TITLE
Fix templates for Tera v2 / Zola 0.23 compatibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
     {% block header %}
     <header class="space">
         <h1>{{ config.title }}</h1>
-        {% set linked_pages = section.pages | filter(attribute="extra.in_header") %}
+        {% set linked_pages = [p for p in section.pages if p.extra.in_header | default(value=false)] %}
         {% if config.extra.links or linked_pages %}
         <nav class="header-links">
             {% for link in config.extra.links %}
@@ -55,7 +55,7 @@
         {% if blog.pages %}
         <h2>Recent posts</h2>
         <ul>
-            {% for post in blog.pages | slice(end=20) %}
+            {% for post in blog.pages[:20] %}
             <li><a href="{{ post.permalink }}">{{ post.title }}</a></li>
             {% endfor %}
         </ul>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "index.html" %}
 
 {% block title %}{{ config.title }} | {{ page.title }}{% endblock title %}
-{% block description %}{{ page.description | default(value=config.description) }}{% endblock description %}
+{% block description %}{{ page?.description or config.description }}{% endblock description %}
 
 {% block header %}
 <header class="space">
@@ -16,11 +16,7 @@
     <p class="secondary small">
         {% if page.date %}{{ page.date | date(format="%-d %B, %Y") }}{% endif %}
 
-        {% set_global sorted_taxonomies = [] %}
-        {% for taxonomy_name, _ in page.taxonomies %}
-        {% set_global sorted_taxonomies = sorted_taxonomies | concat(with=taxonomy_name) %}
-        {% endfor %}
-        {% set_global sorted_taxonomies = sorted_taxonomies | sort %}
+        {% set sorted_taxonomies = [taxonomy_name for taxonomy_name, _ in page.taxonomies] | sort %}
 
         {% for taxonomy_name in sorted_taxonomies %}
         {% set terms = page.taxonomies[taxonomy_name] %}


### PR DESCRIPTION
Zola 0.23 replaced the Tera v1 template engine with Tera v2, which removed the `filter`, `slice`, and `concat` filters and tightened undefined-variable handling. This broke every page built with the theme (index, page, section, taxonomy_list, taxonomy_single, 404).

- Replace `filter(attribute=...)` and `concat(with=...)` with list comprehensions, and `slice(end=...)` with native array slicing, per the Tera v1 -> v2 migration guide.
- Guard `page.description` with optional chaining (`page?.description`) so templates without a `page` in context (404, section, taxonomy_list, taxonomy_single) don't error on an undefined variable.
- Set `min_version` in `theme.toml` to `0.23.0`, the first Zola release with Tera v2, so older versions don't pick up the theme and fail with template errors.

Verified by building the theme's demo content with Zola 0.23.0 — all pages render without errors.
